### PR TITLE
Add StudyAbroad Platform skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # pythonGroupB
-This repository belongs to Gangadhar Reddy The repository is created as part of python project to be worked as part of GMP 21 Group members:
-
+This repository belongs to Gangadhar Reddy The repository is created as part of python project to be worked as part of GMP 21
+Group members:
 1. Gangadhar Reddy
 2. Kaushik Durgam
 3. Yogeshwar Krishna
 4. Vaibhav
+
+## StudyAbroad Platform
+The repository also contains a demo full-stack project for international students.

--- a/studyabroad-platform/.github/workflows/ci.yml
+++ b/studyabroad-platform/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        ports: ['5432:5432']
+        env:
+          POSTGRES_DB: studyabroad
+          POSTGRES_USER: admin
+          POSTGRES_PASSWORD: admin
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install deps
+        run: npm install -g pnpm && pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm build
+      - name: Test
+        run: pnpm test

--- a/studyabroad-platform/README.md
+++ b/studyabroad-platform/README.md
@@ -1,0 +1,5 @@
+# StudyAbroad Platform
+
+A demo full-stack project for managing visas, expenses, jobs and community for international students.
+
+This project includes a Next.js frontend and an Express API backend using Prisma and PostgreSQL.

--- a/studyabroad-platform/apps/api/package.json
+++ b/studyabroad-platform/apps/api/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "api",
+  "private": true,
+  "scripts": {
+    "dev": "ts-node-dev src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "jsonwebtoken": "^9.0.0",
+    "bcryptjs": "^2.4.3",
+    "@prisma/client": "^5.7.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.4",
+    "ts-node-dev": "^2.0.0",
+    "@types/express": "^4.17.17",
+    "@types/node": "^18.11.9",
+    "prisma": "^5.7.1",
+    "vitest": "^0.34.0"
+  }
+}

--- a/studyabroad-platform/apps/api/prisma/schema.prisma
+++ b/studyabroad-platform/apps/api/prisma/schema.prisma
@@ -1,0 +1,86 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id          Int      @id @default(autoincrement())
+  name        String
+  email       String   @unique
+  passwordHash String
+  avatarUrl   String?
+  profilePct  Int      @default(0)
+  posts       Post[]
+  expenses    Expense[]
+  visaSteps   VisaStep[]
+  notifications Notification[]
+}
+
+model Destination {
+  id      Int @id @default(autoincrement())
+  country String
+  city    String
+}
+
+model VisaStep {
+  id      Int    @id @default(autoincrement())
+  user    User   @relation(fields: [userId], references: [id])
+  userId  Int
+  title   String
+  dueDate DateTime
+  status  String
+}
+
+model Expense {
+  id          Int    @id @default(autoincrement())
+  user        User   @relation(fields: [userId], references: [id])
+  userId      Int
+  date        DateTime
+  category    String
+  amount      Float
+  description String
+}
+
+model Post {
+  id      Int    @id @default(autoincrement())
+  user    User   @relation(fields: [userId], references: [id])
+  userId  Int
+  title   String
+  bodyMd  String
+  country String
+}
+
+model Job {
+  id       Int    @id @default(autoincrement())
+  title    String
+  company  String
+  location String
+  type     String
+  category String
+  wage     Float
+}
+
+model Application {
+  id         Int   @id @default(autoincrement())
+  user       User  @relation(fields: [userId], references: [id])
+  userId     Int
+  job        Job   @relation(fields: [jobId], references: [id])
+  jobId      Int
+  status     String
+  appliedAt  DateTime @default(now())
+}
+
+model Notification {
+  id        Int    @id @default(autoincrement())
+  user      User   @relation(fields: [userId], references: [id])
+  userId    Int
+  type      String
+  refId     Int?
+  msg       String
+  read      Boolean @default(false)
+  createdAt DateTime @default(now())
+}

--- a/studyabroad-platform/apps/api/src/index.ts
+++ b/studyabroad-platform/apps/api/src/index.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.get('/api/health', (_req, res) => {
+  res.json({ ok: true });
+});
+
+const port = process.env.PORT || 4000;
+app.listen(port, () => {
+  console.log(`API listening on ${port}`);
+});

--- a/studyabroad-platform/apps/api/test/basic.test.ts
+++ b/studyabroad-platform/apps/api/test/basic.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('api sample', () => {
+  it('2 + 2 equals 4', () => {
+    expect(2 + 2).toBe(4);
+  });
+});

--- a/studyabroad-platform/apps/api/tsconfig.json
+++ b/studyabroad-platform/apps/api/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../packages/config/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/studyabroad-platform/apps/web/next.config.js
+++ b/studyabroad-platform/apps/web/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+module.exports = nextConfig;

--- a/studyabroad-platform/apps/web/package.json
+++ b/studyabroad-platform/apps/web/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "web",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "next": "14.0.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.26",
+    "@types/node": "^18.11.9",
+    "typescript": "^5.0.4",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "vitest": "^0.34.0"
+  }
+}

--- a/studyabroad-platform/apps/web/postcss.config.js
+++ b/studyabroad-platform/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/studyabroad-platform/apps/web/src/app/layout.tsx
+++ b/studyabroad-platform/apps/web/src/app/layout.tsx
@@ -1,0 +1,12 @@
+import '@/styles/globals.css';
+import { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="font-sans">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/studyabroad-platform/apps/web/src/app/page.tsx
+++ b/studyabroad-platform/apps/web/src/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">StudyAbroad Platform</h1>
+    </main>
+  );
+}

--- a/studyabroad-platform/apps/web/src/styles/globals.css
+++ b/studyabroad-platform/apps/web/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/studyabroad-platform/apps/web/tailwind.config.js
+++ b/studyabroad-platform/apps/web/tailwind.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#6366F1',
+        secondary: '#2E52ED',
+        accent: '#F59E0B',
+        background: '#F8FAFC',
+        cardBg: '#FFFFFF',
+        border: '#E2E8F0'
+      },
+      borderRadius: {
+        DEFAULT: '12px'
+      }
+    }
+  },
+  plugins: []
+};

--- a/studyabroad-platform/apps/web/test/basic.test.ts
+++ b/studyabroad-platform/apps/web/test/basic.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('true is truthy', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/studyabroad-platform/apps/web/tsconfig.json
+++ b/studyabroad-platform/apps/web/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../packages/config/tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "baseUrl": "."
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/studyabroad-platform/docker-compose.yml
+++ b/studyabroad-platform/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: studyabroad
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+    ports:
+      - '5432:5432'
+  api:
+    build: ./apps/api
+    environment:
+      DATABASE_URL: postgresql://admin:admin@db:5432/studyabroad
+    depends_on:
+      - db
+    ports:
+      - '4000:4000'
+  web:
+    build: ./apps/web
+    depends_on:
+      - api
+    ports:
+      - '3000:3000'

--- a/studyabroad-platform/package.json
+++ b/studyabroad-platform/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "studyabroad-platform",
+  "private": true,
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "pnpm -r build",
+    "dev": "pnpm -r dev",
+    "test": "pnpm -r test"
+  }
+}

--- a/studyabroad-platform/packages/config/eslint.js
+++ b/studyabroad-platform/packages/config/eslint.js
@@ -1,0 +1,7 @@
+module.exports = {
+  env: { es2021: true, node: true },
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  rules: {},
+};

--- a/studyabroad-platform/packages/config/tsconfig.json
+++ b/studyabroad-platform/packages/config/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/studyabroad-platform/packages/ui/index.tsx
+++ b/studyabroad-platform/packages/ui/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const Button: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({ children, ...props }) => (
+  <button className="px-4 py-2 bg-indigo-500 text-white rounded" {...props}>
+    {children}
+  </button>
+);

--- a/studyabroad-platform/pnpm-workspace.yaml
+++ b/studyabroad-platform/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'

--- a/test.py
+++ b/test.py
@@ -1,4 +1,4 @@
 print("Hello")
-Print("Successfully cloned to the local repository")
+print("Successfully cloned to the local repository")
 
-print("Successfully staged and committted")
+print("Successfully staged and committed")


### PR DESCRIPTION
## Summary
- set up placeholder full-stack project called **StudyAbroad Platform**
- add Next.js web app with Tailwind CSS
- add Express API with Prisma schema
- define shared configs and simple UI package
- include CI workflow and docker-compose setup
- fix minor typos in existing `test.py`

## Testing
- `python3 test.py`
- `pnpm install --no-frozen-lockfile` *(fails: GET https://registry.npmjs.org/... 403)*
- `pnpm test` *(fails: vitest not found because dependencies aren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_68409a0055a8832b81ea1a44a7a1fd13